### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var PayFlowGateway = require('./lib/PayFlowGateway.js');
 var PayFlowReport = require('./lib/PayFlowReport.js');
 
 module.exports = {
-  gateway: function factory(conf) {
+  Gateway: function factory(conf) {
     return new PayFlowGateway(conf);
   },
   report: {


### PR DESCRIPTION
Fix solves following linting error: 'A constructor name should not start with a lowercase letter'.

http://eslint.org/docs/rules/new-cap